### PR TITLE
#00: Configura publicação do front-end

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,8 @@
-
 apply plugin: 'idea'
+
+task build(
+    dependsOn: [
+        ':webservice:build',
+        ':webapp:build'
+    ]
+)

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,14 @@
 apply plugin: 'idea'
 
-task build(
+idea {
+    module {
+        downloadSources = true
+    }
+}
+
+task buildProductionBundle(
     dependsOn: [
         ':webservice:build',
-        ':webapp:build'
+        ':webapp:buildForProduction'
     ]
 )

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,6 @@
 rootProject.name = 'easy-beasy'
-include 'webservice'
+
+include(
+    'webservice',
+    'webapp'
+)

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id "com.moowork.node" version "1.3.1"
+}
+
+task yarnInstall(type: YarnTask) {
+    args = ['install']
+}
+
+task yarnServe(type: YarnTask) {
+    args = ['serve']
+}
+
+task build(type: YarnTask) {
+    args = [
+        'vue-cli-service',
+        'build',
+        '--dest',
+        "${project.project(":webservice").buildDir}/resources/main/static"
+    ]
+}
+

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -2,20 +2,27 @@ plugins {
     id "com.moowork.node" version "1.3.1"
 }
 
+def buildCommandForEnvironment = { mode ->
+    [
+        'vue-cli-service',
+        'build',
+        '--mode',
+        mode,
+        '--dest',
+        "${project(':webservice').buildDir}/resources/main/static"
+    ]
+}
+
+// TODO: Ter uma task para executar install --production
 task yarnInstall(type: YarnTask) {
     args = ['install']
 }
 
-task yarnServe(type: YarnTask) {
-    args = ['serve']
+task buildForProduction(dependsOn: yarnInstall, type: YarnTask) {
+    args = buildCommandForEnvironment('production')
 }
 
-task build(type: YarnTask) {
-    args = [
-        'vue-cli-service',
-        'build',
-        '--dest',
-        "${project.project(":webservice").buildDir}/resources/main/static"
-    ]
+task buildForDevelopment(dependsOn: yarnInstall, type: YarnTask) {
+    args = buildCommandForEnvironment('development') + ['--watch']
 }
 

--- a/webapp/src/components/Home.vue
+++ b/webapp/src/components/Home.vue
@@ -42,7 +42,6 @@ export default {
     service.getPessoas().then(r => {
       // eslint-disable-next-line
       console.log(r);
-      
     })
   }
 }

--- a/webapp/src/services/pessoas.service.js
+++ b/webapp/src/services/pessoas.service.js
@@ -1,8 +1,8 @@
 import http from '../utils/http'
 
 export default {
-   getPessoas : ()   => http.get(`/pessoas`),
-   getPessoa  : (id) => http.get(`/pessoas/${id}`)
+  getPessoas : ()   => http.get(`/testeum/`),
+  getPessoa  : (id) => http.get(`/pessoas/${id}`)
 
 }
 

--- a/webapp/src/utils/http.js
+++ b/webapp/src/utils/http.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
 const client = axios.create({
-    baseURL: 'localhost:8080/ws/',
+    baseURL: '/ws/',
     timeout: 5000});
 export default client;

--- a/webservice/build.gradle
+++ b/webservice/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     }
 }
 
-apply plugin: 'idea'
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
@@ -18,21 +17,23 @@ apply plugin: 'io.spring.dependency-management'
 sourceCompatibility = 11
 targetCompatibility = 11
 
-idea {
-    module {
-        downloadSources = true
+configurations {
+    developmentOnly
+    runtimeClasspath {
+        extendsFrom developmentOnly
     }
 }
 
 dependencies {
     compile "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
     compile "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
-    compile "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
     compile "org.flywaydb:flyway-core"
     compile "org.postgresql:postgresql:42.2.5"
 
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:2.21.0"
+
+    developmentOnly "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
 }
 
 repositories {
@@ -40,9 +41,8 @@ repositories {
 }
 
 bootRun {
-  def activeProfiles = 'dev'
-
-  jvmArgs = [
-    "-Dspring.profiles.active=$activeProfiles"
-  ]
+    doFirst {
+        systemProperty "spring.profiles.active", "dev"
+        systemProperty "spring.devtools.restart.additional-paths", "${project.project(':webapp').projectDir}"
+    }
 }

--- a/webservice/src/main/java/com/thoughtworks/aceleradora/controladores/PerguntaControlador.java
+++ b/webservice/src/main/java/com/thoughtworks/aceleradora/controladores/PerguntaControlador.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/testeum")
+@RequestMapping("/ws/testeum")
 public class PerguntaControlador {
     private PerguntaServico perguntaServico;
 

--- a/webservice/src/main/resources/application.yml
+++ b/webservice/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   jpa:
     show-sql: true

--- a/webservice/src/main/resources/application.yml
+++ b/webservice/src/main/resources/application.yml
@@ -1,3 +1,4 @@
+
 spring:
   jpa:
     show-sql: true


### PR DESCRIPTION
Este Pull Request unifica os artefatos de backend e front-end. As tasks adicionadas permitem que ambos back-end e front-end sejam testados e publicados como uma única aplicação. O objetivo é simplificar a infraestrutura da aplicação sem alterar a estrutura lógica que existe hoje (separação entre `webapp` e `webservice`). 

### Artefato unificado

A estratégia para unificar os artefatos é bastante ~tosca~ minimalista. A ideia é direcionar os artefatos do front-end para dentro das pastas geradas na construção dos artefatos do backend. Desta forma, os artefatos de front-end estarão incluídos nos artefatos do backend.

Em outras palavras, a saída do Webpack é jogada na pasta `build/resources/main/static` e acaba sendo incluída no jar final da aplicação e seus recursos estáticos.

### Hot swapping

Obs.: Hot swapping é a funcionalidade que recarrega a aplicação automaticamente quando há uma mudança de código.

Além da unificação, algumas tarefas de hot swapping foram adicionadas para facilitar o fluxo de desenvolvimento da aplicação. Infelizmente, ainda não encontrei um comando que faça o reload do back-end e do front-end juntos, portanto, precisamos rodar watchers para cada um separadamente. Ou seja:

Temos que abrir três terminais:

Um para executar o watcher do back-end:

```sh
./gradlew build --continuous
```

Um para executar o watcher do front-end:

```sh
./gradlew buildForDevelopment
```

Um para executar a aplicação em modo de desenvolvimento:

```sh
./gradlew bootRun
```

Eu também não tenho muita certeza se os nomes das tasks são descritivos o suficiente.

### Bundle de produção

A gente também precisa testar o bundling de produção e o Heroku certamente exigirá mudanças nas nossas tasks para funcionar corretamente, mas eu não implementei nada disso até o momento.

https://devcenter.heroku.com/articles/deploying-gradle-apps-on-heroku#verify-that-your-build-file-is-set-up-correctly