### PR TITLE
Configura Hot Swapping conjunto

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ idea {
     }
 }
 
-task buildProductionBundle(
+task buildForProduction(
     dependsOn: [
-        ':webservice:build',
-        ':webapp:buildForProduction'
+        ':webapp:buildForProduction',
+        ':webservice:build'
     ]
 )

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -2,15 +2,19 @@ plugins {
     id "com.moowork.node" version "1.3.1"
 }
 
+buildDir = "$projectDir/dist"
+
 def buildCommandForEnvironment = { mode ->
     [
         'vue-cli-service',
         'build',
         '--mode',
-        mode,
-        '--dest',
-        "${project(':webservice').buildDir}/resources/main/static"
+        mode
     ]
+}
+
+task clean(type: Delete) {
+    delete buildDir
 }
 
 // TODO: Ter uma task para executar install --production
@@ -18,11 +22,18 @@ task yarnInstall(type: YarnTask) {
     args = ['install']
 }
 
-task buildForProduction(dependsOn: yarnInstall, type: YarnTask) {
+task buildForProduction(dependsOn: clean, type: YarnTask) {
     args = buildCommandForEnvironment('production')
 }
 
-task buildForDevelopment(dependsOn: yarnInstall, type: YarnTask) {
-    args = buildCommandForEnvironment('development') + ['--watch']
+task buildForDevelopment(type: YarnTask) {
+    inputs.dir("$projectDir/src")
+    inputs.dir("$projectDir/public")
+    inputs.file("$projectDir/babel.config.js")
+    inputs.file("$projectDir/package.json")
+    
+    outputs.dir buildDir
+
+    args = buildCommandForEnvironment('development')
 }
 

--- a/webservice/build.gradle
+++ b/webservice/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
     }
 }
 
@@ -25,24 +25,33 @@ configurations {
 }
 
 dependencies {
-    compile "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-    compile "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
+    compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+    compile "org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion"
     compile "org.flywaydb:flyway-core"
     compile "org.postgresql:postgresql:42.2.5"
 
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:2.21.0"
 
-    developmentOnly "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
+    developmentOnly "org.springframework.boot:spring-boot-devtools:$springBootVersion"
 }
 
 repositories {
     mavenCentral()
 }
 
+def frontendProject = project(':webapp')
+
 bootRun {
     doFirst {
         systemProperty "spring.profiles.active", "dev"
-        systemProperty "spring.devtools.restart.additional-paths", "${project.project(':webapp').projectDir}"
+    }
+}
+
+clean.dependsOn frontendProject.tasks.clean
+
+processResources {
+    from(frontendProject.buildDir) {
+        into 'static'
     }
 }


### PR DESCRIPTION
Esta PR configura tasks do Gradle para que o hot swapping funcione tanto para o front-end quanto para o backend ao mesmo tempo.

Para rodar a aplicação em modo de hot swapping, é necessário executar dois comandos em separado:

O hot swapping propriamente dito:

```sh
./gradlew -t build buildForDevelopment
```

A aplicação:

```sh
./gradlew bootrun
```

Isso é possível graças aos recursos de Incremental Build e Continuous Building do gradle:
 - https://blog.gradle.org/introducing-incremental-build-support
 - https://blog.gradle.org/introducing-continuous-build

Além do hot swapping, a configuração também deixa a construção do artefato mais confiável. Ao invés de direcionar a saída do Webpack para a pasta resources (o que burlava o ciclo de vida do Gradle e poderia nos morder mais tarde), o build script agora utiliza os recursos do próprio Gradle para executar esta tarefa (através da tarefa de `processResources`, mais especificamente).
