### PR TITLE
97/cadastrar perguntas back

### DIFF
--- a/webservice/src/main/java/com/thoughtworks/aceleradora/controller/QuestionController.java
+++ b/webservice/src/main/java/com/thoughtworks/aceleradora/controller/QuestionController.java
@@ -1,0 +1,24 @@
+package com.thoughtworks.aceleradora.controller;
+
+import com.thoughtworks.aceleradora.domain.Question;
+import com.thoughtworks.aceleradora.service.QuestionService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/question")
+public class QuestionController {
+    private QuestionService questionService;
+
+
+    public QuestionController(QuestionService questionService) {
+        this.questionService = questionService;
+    }
+
+    @PostMapping("/")
+    public Question save(@RequestBody Question question) {
+        return questionService.save(question);
+    }
+}

--- a/webservice/src/main/java/com/thoughtworks/aceleradora/domain/Question.java
+++ b/webservice/src/main/java/com/thoughtworks/aceleradora/domain/Question.java
@@ -19,13 +19,20 @@ public class Question {
 
     private String description;
 
+    private Long id_stage;
+
     @JsonCreator
-    public Question(@JsonProperty("description") String description) {
+    public Question(@JsonProperty("description") String description, @JsonProperty("id_stage") Long id_stage) {
         this.description = description;
+        this.id_stage = id_stage;
     }
 
     @JsonCreator
     public Question() {
+    }
+
+    public Question(String question) {
+
     }
 
     public String getDescription() {

--- a/webservice/src/main/java/com/thoughtworks/aceleradora/service/QuestionService.java
+++ b/webservice/src/main/java/com/thoughtworks/aceleradora/service/QuestionService.java
@@ -1,0 +1,21 @@
+package com.thoughtworks.aceleradora.service;
+
+import com.thoughtworks.aceleradora.domain.Question;
+import com.thoughtworks.aceleradora.repository.QuestionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class QuestionService {
+    private QuestionRepository repository;
+
+    @Autowired
+    public QuestionService(QuestionRepository repository) {
+        this.repository = repository;
+    }
+
+    public Question save(Question question) {
+        return repository.save(question);
+    }
+
+}

--- a/webservice/src/test/java/com/thoughtworks/aceleradora/service/QuestionServiceTest.java
+++ b/webservice/src/test/java/com/thoughtworks/aceleradora/service/QuestionServiceTest.java
@@ -1,0 +1,49 @@
+package com.thoughtworks.aceleradora.service;
+
+import com.thoughtworks.aceleradora.domain.Question;
+import com.thoughtworks.aceleradora.repository.QuestionRepository;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QuestionServiceTest {
+
+    @Mock
+    private QuestionRepository repository;
+
+    @InjectMocks
+    private QuestionService questionService;
+
+    @Rule
+    public ExpectedException
+            expectedException = ExpectedException.none();
+    private Question expectedQuestion;
+
+    @Before
+    public  void setup(){
+        expectedQuestion = new Question("description");
+    }
+
+    @Test
+    public void shouldReturnOKIfAddValidStage() {
+
+        when(repository.save(expectedQuestion)).thenReturn(expectedQuestion);
+
+        Question questions = questionService.save(expectedQuestion);
+
+        Assert.assertEquals(expectedQuestion.getDescription(), questions.getDescription());
+
+        Mockito.verify(repository, Mockito.times(1)).save(expectedQuestion);
+    }
+}


### PR DESCRIPTION
Esse PR faz:
Cria um endpoint na controller para salvar uma nova pergunta;
Salvar os dados da nova pergunta no banco de dados
 Salvar pergunta através de requisição externa