### PR TITLE
Expedite/refatora css

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -12,13 +12,6 @@ export default {
 </script>
 
 <style lang="scss">
-#app {
-  font-family: "Lato, sans-serif", serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #00c1b9;
-  background-color:#baf8fa;
-}
+
 
 </style>

--- a/webapp/src/components/Diagnosis.vue
+++ b/webapp/src/components/Diagnosis.vue
@@ -28,6 +28,7 @@ header {
   font-family: $primary-font-family;
 }
 h2 {
+    text-align: center;
   color: $text-header-color;
 }
 </style>


### PR DESCRIPTION
Removemos o CSS da classe App, porque o CSS ficava global e era aplicado a todas as telas.